### PR TITLE
Fix broken totem descriptions in en_US.json

### DIFF
--- a/src/main/resources/assets/changed_addon/lang/en_us.json
+++ b/src/main/resources/assets/changed_addon/lang/en_us.json
@@ -577,5 +577,9 @@
   "advancements.friendly_transfur.descr": "You get Transfured by Foxyas",
   "changed_addon.ability.carry": "Carry",
   "gui.changed_addon.unifusergui.label_next_page": "Next Page",
-  "key.categories.changed_addon": "Changed Addon Keybinds"
+  "key.categories.changed_addon": "Changed Addon Keybinds",
+  "entity.changed_addon.exp1_male": "Exp 1 Male",
+  "entity.changed_addon.exp1_female": "Exp 1 Female",
+  "entity.changed_addon.luminarctic_leopard_male": "Luminarctic Leopard",
+  "entity.changed_addon.luminarctic_leopard_female": "Female Luminarctic Leopard"
 }


### PR DESCRIPTION
Broken Translation Key on totems patches. This is a bandage fix and should be done by removing every duplicated translation key, but it's good enough for now.